### PR TITLE
Feat/managing member

### DIFF
--- a/src/main/java/GDG/whatssue/domain/file/service/impl/S3UploadService.java
+++ b/src/main/java/GDG/whatssue/domain/file/service/impl/S3UploadService.java
@@ -35,7 +35,7 @@ public class S3UploadService implements FileUploadService {
 
         //저장 사진이 없으면 기본 경로 반환
         if (multipartFile == null) {
-            storeFileName = dirName + FileConst.DEFAULT_IMAGE_NAME;
+            return storeFileName = dirName + FileConst.DEFAULT_IMAGE_NAME;
         }
 
         storeFileName = getFileName(dirName, multipartFile.getOriginalFilename());

--- a/src/main/java/GDG/whatssue/domain/member/controller/ClubMemberController.java
+++ b/src/main/java/GDG/whatssue/domain/member/controller/ClubMemberController.java
@@ -1,10 +1,6 @@
 package GDG.whatssue.domain.member.controller;
 
-import GDG.whatssue.domain.member.dto.ClubMemberDto;
-import GDG.whatssue.domain.member.dto.ClubMemberInfoDto;
-import GDG.whatssue.domain.member.dto.CreateMemberProfileRequest;
-import GDG.whatssue.domain.member.dto.MemberAuthInfoResponse;
-import GDG.whatssue.domain.member.dto.MemberProfileDto;
+import GDG.whatssue.domain.member.dto.*;
 import GDG.whatssue.domain.member.service.ClubMemberManagingService;
 import GDG.whatssue.domain.member.service.ClubMemberService;
 import GDG.whatssue.global.common.annotation.ClubManager;
@@ -12,13 +8,18 @@ import GDG.whatssue.global.common.annotation.LoginUser;
 import GDG.whatssue.global.common.annotation.SkipFirstVisitCheck;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+
+import java.beans.PropertyEditorSupport;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.support.ByteArrayMultipartFileEditor;
 
 @Slf4j
 @RestController
@@ -44,13 +45,24 @@ public class ClubMemberController {
         return new ResponseEntity("ok", HttpStatus.OK);
     }
 
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        binder.registerCustomEditor(MultipartFile.class, new PropertyEditorSupport() {
+            @Override
+            public void setAsText(String text) {
+                setValue(null);
+            }
+
+        });
+    }
+
+
     @PostMapping(value = "/profile/modify", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "멤버 프로필 수정")
     public ResponseEntity<Void> modifyProfile(
             @LoginUser Long userId,
             @PathVariable Long clubId,
-            @Valid @ModelAttribute CreateMemberProfileRequest request) throws IOException {
-
+            @Valid @ModelAttribute ModifyMemberProfileRequest request) throws IOException {
         clubMemberService.modifyClubMember(clubId,userId, request);
         return ResponseEntity.status(HttpStatus.OK).build();
 

--- a/src/main/java/GDG/whatssue/domain/member/dto/ModifyMemberProfileRequest.java
+++ b/src/main/java/GDG/whatssue/domain/member/dto/ModifyMemberProfileRequest.java
@@ -1,7 +1,6 @@
 package GDG.whatssue.domain.member.dto;
 
-import GDG.whatssue.domain.member.entity.ClubMember;
-import jakarta.validation.constraints.NotBlank;
+import GDG.whatssue.domain.member.entity.ImgModifyStatus;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -10,7 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
-public class CreateMemberProfileRequest {
+public class ModifyMemberProfileRequest {
 
     @Size(min = 1, max = 15, message = "멤버 이름은 최소 1자, 최대 15자까지 입니다.")
     private String memberName;
@@ -25,4 +24,6 @@ public class CreateMemberProfileRequest {
     private Boolean isPhonePublic;
 
     private MultipartFile profileImage;
+
+    private ImgModifyStatus ImageModifyStatus;
 }

--- a/src/main/java/GDG/whatssue/domain/member/entity/ClubMember.java
+++ b/src/main/java/GDG/whatssue/domain/member/entity/ClubMember.java
@@ -48,7 +48,7 @@ public class ClubMember extends BaseEntity {
     @Column(nullable = false)
     private boolean isFirstVisit;
 
-    @OneToOne(mappedBy = "clubMember", cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, fetch = FetchType.LAZY) //지연 로딩 설정
+    @OneToOne(mappedBy = "clubMember", cascade = {CascadeType.REMOVE, CascadeType.ALL}, fetch = FetchType.LAZY) //지연 로딩 설정
     private MemberProfileImage profileImage;
 
     //==연관관계 메서드==//

--- a/src/main/java/GDG/whatssue/domain/member/entity/ImgModifyStatus.java
+++ b/src/main/java/GDG/whatssue/domain/member/entity/ImgModifyStatus.java
@@ -1,0 +1,10 @@
+package GDG.whatssue.domain.member.entity;
+
+
+public enum ImgModifyStatus {
+
+    MODIFY,
+    DELETE,
+    NO_MODIFY
+
+}

--- a/src/main/java/GDG/whatssue/domain/member/exception/ClubMemberErrorCode.java
+++ b/src/main/java/GDG/whatssue/domain/member/exception/ClubMemberErrorCode.java
@@ -12,7 +12,9 @@ public enum ClubMemberErrorCode implements ErrorCode {
 
     EX2200("2200", HttpStatus.PRECONDITION_REQUIRED, "멤버 프로필 초기 설정이 필요합니다."),
 
-    EX2201("2201", HttpStatus.BAD_REQUEST, "멤버 프로필 설정은 최초에만 가능합니다.");
+    EX2201("2201", HttpStatus.BAD_REQUEST, "멤버 프로필 설정은 최초에만 가능합니다."),
+
+    EX2202("2202", HttpStatus.BAD_REQUEST, "이미지가 null 입니다. 이미지를 업로드해주세요.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/GDG/whatssue/domain/member/service/ClubMemberService.java
+++ b/src/main/java/GDG/whatssue/domain/member/service/ClubMemberService.java
@@ -8,6 +8,7 @@ import GDG.whatssue.domain.file.repository.FileRepository;
 import GDG.whatssue.domain.file.service.FileUploadService;
 import GDG.whatssue.domain.member.dto.*;
 import GDG.whatssue.domain.member.entity.ClubMember;
+import GDG.whatssue.domain.member.entity.ImgModifyStatus;
 import GDG.whatssue.domain.member.exception.ClubMemberErrorCode;
 import GDG.whatssue.domain.member.repository.ClubMemberRepository;
 import GDG.whatssue.domain.user.Error.UserErrorCode;
@@ -26,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import static GDG.whatssue.domain.club.entity.NamePolicy.REAL_NAME;
 import static GDG.whatssue.domain.file.FileConst.MEMBER_PROFILE_IMAGE_DIRNAME;
+import static GDG.whatssue.domain.member.entity.ImgModifyStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -38,31 +40,41 @@ public class ClubMemberService {
     private final FileUploadService fileUploadService;
 
     @Transactional
-    public void modifyClubMember(Long clubId, Long userId, CreateMemberProfileRequest request) throws IOException {
+    public void modifyClubMember(Long clubId, Long userId, ModifyMemberProfileRequest request) throws IOException {
 
         Club club = clubRepository.findById(clubId).get();
         NamePolicy namePolicy = club.getNamePolicy();
 
         ClubMember clubMember = clubMemberRepository.findById(getClubMemberId(clubId,userId)).get();
+        ImgModifyStatus imageModifyStatus = request.getImageModifyStatus();
 
-        // 멤버 프로필 이미지 저장
-        MultipartFile multipartFile = request.getProfileImage();
-
-        String storeFileName = fileUploadService.uploadFile(multipartFile, MEMBER_PROFILE_IMAGE_DIRNAME);
-        String originalFileName = fileUploadService.getOriginalFileName(multipartFile);
-
-        if(clubMember.getProfileImage() != null) {
+       if(imageModifyStatus == DELETE) {
 
             MemberProfileImage memberProfileImage = clubMember.getProfileImage();
-            // 버킷에서 기존 사진 삭제
-            fileUploadService.deleteFile(memberProfileImage.getStoreFileName());
-            // DB 새로운 사진으로 업데이트
-            memberProfileImage.update(originalFileName, storeFileName);
+            // 버킷에서 사진 삭제
 
-        }else{
-            MemberProfileImage memberProfileImage = MemberProfileImage.of(originalFileName, storeFileName);
-            clubMember.changeProfileImage(memberProfileImage);
-        }
+           fileUploadService.deleteFile(memberProfileImage.getStoreFileName());
+            // 프로필 이미지 삭제 - multipart file == null 인 경우 기본 이미지
+           String storeFileName = fileUploadService.uploadFile(null, MEMBER_PROFILE_IMAGE_DIRNAME);
+           String originalFileName = fileUploadService.getOriginalFileName(null);
+           // 기본 이미지로 업데이트
+           memberProfileImage.update(originalFileName, storeFileName);
+
+        } else if (imageModifyStatus == MODIFY){
+           if(request.getProfileImage() == null ) throw new CommonException(ClubMemberErrorCode.EX2202);
+
+           // 멤버 프로필 이미지 저장
+           MultipartFile multipartFile = request.getProfileImage();
+
+           String storeFileName = fileUploadService.uploadFile(multipartFile, MEMBER_PROFILE_IMAGE_DIRNAME);
+           String originalFileName = fileUploadService.getOriginalFileName(multipartFile);
+           MemberProfileImage currentProfileImage = clubMember.getProfileImage();
+           // 버킷에서 기존 사진 삭제
+           fileUploadService.deleteFile(currentProfileImage.getStoreFileName());
+           // DB 새로운 사진으로 업데이트
+           currentProfileImage.update(originalFileName, storeFileName);
+
+       }
 
         // 멤버 프로필 정보 업데이트
         String memberName;

--- a/src/main/java/GDG/whatssue/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/GDG/whatssue/global/error/GlobalExceptionHandler.java
@@ -128,7 +128,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<ErrorResult> allExHandle(Exception e, HttpServletRequest request) {
-        log.warn("exception= {}", e.getMessage());
+        log.warn("exception= {}", e);
         ErrorCode errorCode = CommonErrorCode.EX0400;
         ErrorResult errorResult = ErrorResult.builder()
             .code(errorCode.getCode())


### PR DESCRIPTION
## Description
1. modifyImage request 상태를 위한 enum 추가 
2. 상태별 이미지 다르게 처리 
3. multi file 객체가 null 인 경우에 대한 return 누락 수정 
4. 이미지가 MultipartFiler 객체가 아닌  String = "" 으로 들어오는 경우를 위해 String 을 null로 만들어주는 initBinder 추가  

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [x] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?

1. 조건문으로 Null 여부를 확인해서 delete, modify, no modify 에대한 기능을 구현함

## What is the new behavior?

1. enum을 추가하여 delete, modify, no modify 에대한 기능을 구현함
2. 이미지가 비어 있는 경우 비어있는 String으로 들어오는 문제가 발생 => initBinder 추가
